### PR TITLE
Feat: Prevent duplicate guesses

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,7 @@ p {
   display: flex;
   direction: row;
   align-items: center;
+  perspective: 1000px;
 }
 
 .attribute {
@@ -55,6 +56,8 @@ p {
   display: flex;
   align-items: center;
   justify-content: center;
+  transform-style: preserve-3d;
+  overflow: hidden;
 }
 
 .red {
@@ -75,28 +78,32 @@ p {
 }
 
 .character-image-column{
-  width: 90px;
-  height: 100px;
+  width: 85px;
+  height: 85px;
 }
 
 .flip-cover {
   position: absolute;
-  width: 100%;
-  height: 100%;
-  backface-visibility: hidden;
+  width: 85px;
+  height: 85px;
   backface-visibility: hidden;
   transform: rotateY(180deg);
-  transition: transform 0.5s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
+
+
+
 
 
 .square.flip {
-  animation: flip 0.9s;
-  transform-style: preserve-3d;
+  animation: flip 1s;
 }
 
-.row {
+.square {
   perspective: 1000px;
+  overflow: hidden;
 }
 
 
@@ -104,11 +111,7 @@ p {
   0% {
     transform: rotateY(0deg);
   }
-  50% {
-    transform: rotateY(180deg);
-    visibility: hidden;
-    }
   100% {
-    transform: rotateY(360deg);
-  }
+    transform: rotateY(180deg);
+    }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -79,7 +79,6 @@ p {
   height: 100px;
 }
 
-
 .flip-cover {
   position: absolute;
   width: 100%;
@@ -92,7 +91,7 @@ p {
 
 
 .square.flip {
-  animation: flip 0.5s;
+  animation: flip 0.9s;
   transform-style: preserve-3d;
 }
 
@@ -103,13 +102,13 @@ p {
 
 @keyframes flip {
   0% {
-    transform: rotateY(0);
+    transform: rotateY(0deg);
   }
   50% {
-    transform: rotateY(90deg);
-    visibility: hidden;
-  }
-  100% {
     transform: rotateY(180deg);
+    visibility: hidden;
+    }
+  100% {
+    transform: rotateY(360deg);
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -78,3 +78,38 @@ p {
   width: 90px;
   height: 100px;
 }
+
+
+.flip-cover {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  backface-visibility: hidden;
+  backface-visibility: hidden;
+  transform: rotateY(180deg);
+  transition: transform 0.5s;
+}
+
+
+.square.flip {
+  animation: flip 0.5s;
+  transform-style: preserve-3d;
+}
+
+.row {
+  perspective: 1000px;
+}
+
+
+@keyframes flip {
+  0% {
+    transform: rotateY(0);
+  }
+  50% {
+    transform: rotateY(90deg);
+    visibility: hidden;
+  }
+  100% {
+    transform: rotateY(180deg);
+  }
+}

--- a/src/App.js
+++ b/src/App.js
@@ -6,14 +6,10 @@ import { ATTRIBUTES } from "./const/attributes";
 import { CHARACTERS } from "./const/characters";
 import { NUM_ATTEMPS } from "./const/settings";
 
-
-
-
 function App() {
   const [isCorrect, setIsCorrect] = useState(false);
   const [guesses, setGuesses] = useState([]);
   const [selection, setSelection] = useState();
-  const [isFlipping, setIsFlipping] = useState(false);
   const answer = useMemo(() => {
     const randomInt = Math.floor(Math.random() * CHARACTERS.length);
     console.log("correct answer:", CHARACTERS[randomInt]);
@@ -31,7 +27,6 @@ function App() {
     if (selection == answer) {
       setIsCorrect(true);
     } else if (guesses.length + 1 >= NUM_ATTEMPS) setIsCorrect(false);
-    setIsFlipping(true);
   }
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,10 @@ import { ATTRIBUTES } from "./const/attributes";
 import { CHARACTERS } from "./const/characters";
 import { NUM_ATTEMPS } from "./const/settings";
 
+
+
 function App() {
+  const hello = "Hello world";
   const [isCorrect, setIsCorrect] = useState(false);
   const [guesses, setGuesses] = useState([]);
   const [selection, setSelection] = useState();

--- a/src/App.js
+++ b/src/App.js
@@ -8,11 +8,12 @@ import { NUM_ATTEMPS } from "./const/settings";
 
 
 
+
 function App() {
-  const hello = "Hello world";
   const [isCorrect, setIsCorrect] = useState(false);
   const [guesses, setGuesses] = useState([]);
   const [selection, setSelection] = useState();
+  const [isFlipping, setIsFlipping] = useState(false);
   const answer = useMemo(() => {
     const randomInt = Math.floor(Math.random() * CHARACTERS.length);
     console.log("correct answer:", CHARACTERS[randomInt]);
@@ -30,6 +31,7 @@ function App() {
     if (selection == answer) {
       setIsCorrect(true);
     } else if (guesses.length + 1 >= NUM_ATTEMPS) setIsCorrect(false);
+    setIsFlipping(true);
   }
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,11 @@
-import { Button, Select } from "antd";
-import { useState } from "react";
 import "./App.css";
+import CharacterSelection from "./components/CharacterSelection";
 import { Grid } from "./components/Grid";
-import { ATTRIBUTES } from "./const/attributes";
 import { CHARACTERS } from "./const/characters";
 import { NUM_ATTEMPS } from "./const/settings";
 import useGuesses from "./hooks/useGuesses";
 
 function App() {
-  const [selection, setSelection] = useState();
   const { answer, guesses, isCorrect, addGuess } = useGuesses();
   return (
     <div className="App">
@@ -17,53 +14,11 @@ function App() {
       </header>
       <div className="App-body">
         <Grid answer={answer} guesses={guesses} />
-        <div className="row">
-          <Select
-            showSearch
-            onChange={setSelection}
-            style={{ width: 240 }}
-            filterOption={(input, option) => {
-              console.log({ input, option });
-              return (option?.label ?? "")
-                .toLowerCase()
-                .includes(input.toLowerCase());
-            }}
-            optionLabelProp="label"
-          >
-            {CHARACTERS.map((character, i) => {
-              const imageUrl = `${process.env.PUBLIC_URL}${character.image_url}`;
-              return (
-                <Select.Option
-                  key={i}
-                  value={i}
-                  label={character[ATTRIBUTES.NAME]}
-                >
-                  <div className="character-option">
-                    <img
-                      src={imageUrl}
-                      className="character-image"
-                      alt={character[ATTRIBUTES.NAME]}
-                    />
-                    <span className="character-name">
-                      {character[ATTRIBUTES.NAME]}
-                    </span>
-                  </div>
-                </Select.Option>
-              );
-            })}
-          </Select>
-          <Button
-            type="primary"
-            onClick={() => addGuess(selection)}
-            disabled={
-              isCorrect ||
-              guesses.length >= NUM_ATTEMPS ||
-              selection == undefined
-            }
-          >
-            Make Guess
-          </Button>
-        </div>
+        <CharacterSelection
+          isCorrect={isCorrect}
+          guesses={guesses}
+          addGuess={addGuess}
+        />
         {isCorrect ? (
           <div className="correct_answer">Congrats!</div>
         ) : guesses.length >= NUM_ATTEMPS ? (

--- a/src/components/CharacterSelection.js
+++ b/src/components/CharacterSelection.js
@@ -1,0 +1,62 @@
+import { Button, Select } from "antd";
+import React, { useMemo, useState } from "react";
+import { ATTRIBUTES } from "../const/attributes";
+import { NUM_ATTEMPS } from "../const/settings";
+import { CHARACTERS } from "../const/characters";
+
+function CharacterSelection({ isCorrect, guesses, addGuess }) {
+  const [selection, setSelection] = useState();
+
+  const filteredCharacters = useMemo(() => {
+    return CHARACTERS.filter((character) => !guesses.includes(character.id));
+  }, [guesses]);
+
+  return (
+    <div className="row">
+      <Select
+        showSearch
+        onChange={setSelection}
+        style={{ width: 240 }}
+        filterOption={(input, option) => {
+          return (option?.label ?? "")
+            .toLowerCase()
+            .includes(input.toLowerCase());
+        }}
+        optionLabelProp="label"
+      >
+        {filteredCharacters.map((character) => {
+          const imageUrl = `${process.env.PUBLIC_URL}${character.image_url}`;
+          return (
+            <Select.Option
+              key={character.id}
+              value={character.id}
+              label={character[ATTRIBUTES.NAME]}
+            >
+              <div className="character-option">
+                <img
+                  src={imageUrl}
+                  className="character-image"
+                  alt={character[ATTRIBUTES.NAME]}
+                />
+                <span className="character-name">
+                  {character[ATTRIBUTES.NAME]}
+                </span>
+              </div>
+            </Select.Option>
+          );
+        })}
+      </Select>
+      <Button
+        type="primary"
+        onClick={() => addGuess(selection)}
+        disabled={
+          isCorrect || guesses.length >= NUM_ATTEMPS || selection == undefined
+        }
+      >
+        Make Guess
+      </Button>
+    </div>
+  );
+}
+
+export default CharacterSelection;

--- a/src/components/CharacterSelection.js
+++ b/src/components/CharacterSelection.js
@@ -15,6 +15,7 @@ function CharacterSelection({ isCorrect, guesses, addGuess }) {
     <div className="row">
       <Select
         showSearch
+        value={selection}
         onChange={setSelection}
         style={{ width: 240 }}
         filterOption={(input, option) => {
@@ -48,7 +49,10 @@ function CharacterSelection({ isCorrect, guesses, addGuess }) {
       </Select>
       <Button
         type="primary"
-        onClick={() => addGuess(selection)}
+        onClick={() => {
+          addGuess(selection);
+          setSelection(undefined);
+        }}
         disabled={
           isCorrect || guesses.length >= NUM_ATTEMPS || selection == undefined
         }

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -25,7 +25,8 @@ export function Grid({ answer, guesses }) {
       setFlipState((prevFlipState) => {
         const newFlipState = [...prevFlipState];
         newFlipState[guesses.length - 1] = false;
-        return newFlipState;})
+        return newFlipState;
+      });
     }, 1000);
     return () => clearTimeout(timeoutId);
   }, [guesses]);
@@ -44,9 +45,8 @@ export function Grid({ answer, guesses }) {
           {cols.map((col) => {
             const answered = guesses[row] != undefined;
             const correct =
-              CHARACTERS[guesses[row]]?.[
-                ATTRIBUTE_INDEX[col]
-              ] === CHARACTERS[answer]?.[ATTRIBUTE_INDEX[col]];
+              CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]] ===
+              CHARACTERS[answer]?.[ATTRIBUTE_INDEX[col]];
             const additionalClassName = answered
               ? correct
                 ? "green"
@@ -58,14 +58,13 @@ export function Grid({ answer, guesses }) {
             const value =
               ATTRIBUTE_INDEX[col] === ATTRIBUTES.INITIAL_RELEASE && answered
                 ? releaseYearFunction(
-                    CHARACTERS[guesses[row]]?.[
-                      ATTRIBUTE_INDEX[col]
-                    ],
+                    CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]],
                     answer
                   )
-                : CHARACTERS[guesses[row]]?.[
-                    ATTRIBUTE_INDEX[col]
-                  ];
+                : CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]];
+            const imageUrl = `${process.env.PUBLIC_URL}${
+              CHARACTERS[guesses[row]]?.image_url
+            }`;
             return (
               <div
                 className={`square ${additionalClassName} ${
@@ -78,15 +77,37 @@ export function Grid({ answer, guesses }) {
                     src={`${process.env.PUBLIC_URL}${
                       CHARACTERS[guesses[row]]?.image_url
                     }`}
-                    alt={
-                      CHARACTERS[guesses[row]]?.[
-                        ATTRIBUTE_INDEX[col]
-                      ]
-                    }
+                    alt={CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]]}
                     className="character-image-column"
                   />
                 ) : (
                   value
+                )}
+                {flipState[row] && (
+                  <div className="flip-cover">
+                    {showImage ? (
+                      <img
+                        src={`${process.env.PUBLIC_URL}${
+                          CHARACTERS[guesses[row]]?.image_url
+                        }`}
+                        alt={CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]]}
+                        className="character-image-column"
+                      />
+                    ) : (
+                      value
+                    )}
+                    {showImage ? (
+                      <img
+                        src={`${process.env.PUBLIC_URL}${
+                          CHARACTERS[guesses[row]]?.image_url
+                        }`}
+                        alt={CHARACTERS[guesses[row]]?.[ATTRIBUTE_INDEX[col]]}
+                        className="character-image-column"
+                      />
+                    ) : (
+                      value
+                    )}
+                  </div>
                 )}
               </div>
             );

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -16,12 +16,16 @@ export function Grid({ answer, guesses }) {
   useEffect(() => {
     if (guesses.length === 0) return;
 
-    const newFlipState = [...flipState];
-    newFlipState[guesses.length - 1] = true;
-    setFlipState(newFlipState);
+    setFlipState((prevFlipState) => {
+      const newFlipState = [...prevFlipState];
+      newFlipState[guesses.length - 1] = true;
+      return newFlipState;
+    });
     const timeoutId = setTimeout(() => {
-      newFlipState[guesses.length - 1] = false;
-      setFlipState(newFlipState);
+      setFlipState((prevFlipState) => {
+        const newFlipState = [...prevFlipState];
+        newFlipState[guesses.length - 1] = false;
+        return newFlipState;})
     }, 1000);
     return () => clearTimeout(timeoutId);
   }, [guesses]);
@@ -84,7 +88,6 @@ export function Grid({ answer, guesses }) {
                 ) : (
                   value
                 )}
-                <div className="flip-cover"></div>
               </div>
             );
           })}

--- a/src/components/Grid.js
+++ b/src/components/Grid.js
@@ -6,10 +6,25 @@ import {
 import { CHARACTERS } from "../const/characters";
 import { NUM_ATTEMPS } from "../const/settings";
 import { releaseYearFunction } from "../utils/releaseYearFunction";
+import React, { useState, useEffect } from "react";
 
 export function Grid({ answer, guesses }) {
   const rows = Array.from(Array(NUM_ATTEMPS).keys());
   const cols = Array.from(Array(Object.keys(ATTRIBUTES).length).keys());
+  const [flipState, setFlipState] = useState([]);
+
+  useEffect(() => {
+    if (guesses.length === 0) return;
+
+    const newFlipState = [...flipState];
+    newFlipState[guesses.length - 1] = true;
+    setFlipState(newFlipState);
+    const timeoutId = setTimeout(() => {
+      newFlipState[guesses.length - 1] = false;
+      setFlipState(newFlipState);
+    }, 1000);
+    return () => clearTimeout(timeoutId);
+  }, [guesses]);
 
   return (
     <div>
@@ -48,7 +63,12 @@ export function Grid({ answer, guesses }) {
                     ATTRIBUTE_INDEX[col]
                   ];
             return (
-              <div className={`square ${additionalClassName}`} key={col}>
+              <div
+                className={`square ${additionalClassName} ${
+                  flipState[row] ? "flip" : ""
+                }`}
+                key={col}
+              >
                 {showImage ? (
                   <img
                     src={`${process.env.PUBLIC_URL}${
@@ -64,6 +84,7 @@ export function Grid({ answer, guesses }) {
                 ) : (
                   value
                 )}
+                <div className="flip-cover"></div>
               </div>
             );
           })}

--- a/src/const/characters.js
+++ b/src/const/characters.js
@@ -1,4 +1,4 @@
-export const CHARACTERS = [
+const RAW_CHARACTERS = [
   {
     name: "Mario",
     company: "Nintendo",
@@ -766,3 +766,7 @@ export const CHARACTERS = [
     image_url: "/character-images/Sora.png",
   },
 ];
+
+export const CHARACTERS = Object.values(RAW_CHARACTERS).map((value, i) => {
+  return { ...value, id: i };
+});

--- a/src/hooks/useGuesses.js
+++ b/src/hooks/useGuesses.js
@@ -36,7 +36,7 @@ const useGuesses = () => {
 
   const addGuess = useCallback(
     (guess) => {
-      if (guess === undefined) {
+      if (guess == undefined || guesses.includes(guess)) {
         console.error("Invalid Character");
         return;
       }
@@ -49,7 +49,7 @@ const useGuesses = () => {
         },
       });
     },
-    [answer, todayInt]
+    [answer, todayInt, guesses]
   );
 
   return { answer, guesses, isCorrect, addGuess };


### PR DESCRIPTION
### Issue: #5 

### Changes in this PR
- refactored `CHARACTERS` so that it includes id, used to determine character even if `CHARACTER` list is modified (like some values filtered out)
- new `CharacterSelection` component for Select and Make Guess Button. 
- `Select` options now filters out characters who have been guessed (by checking if `guesses.includes(character.id)` 

### Screenshots
When Link and Yoshi have been guessed, they don't show up in the Select Options:
<img width="653" alt="Screen Shot 2023-04-23 at 12 37 23 PM" src="https://user-images.githubusercontent.com/39861601/233852972-91864260-84c3-42f7-9d0a-a694286a5d3c.png">
If nothing has been guessed, we can see Link and Yoshi in the Select Options: 
<img width="632" alt="Screen Shot 2023-04-23 at 12 37 50 PM 1" src="https://user-images.githubusercontent.com/39861601/233852973-1223035e-fd1f-4551-bc28-1a0ad6dfc8b1.png">
